### PR TITLE
Improve MongoDB startup logging and retries

### DIFF
--- a/server/src/config/db.ts
+++ b/server/src/config/db.ts
@@ -4,25 +4,33 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const connectDB = async (): Promise<void> => {
-  try {
-    const mongoURI = process.env.MONGODB_URI as string;
-    
-    if (!mongoURI) {
-      throw new Error('MongoDB URI is not defined in environment variables');
-    }
-    
-    await mongoose.connect(mongoURI);
-    
-    console.log('MongoDB Connected...');
-  } catch (err) {
-    if (err instanceof Error) {
-      console.error(`MongoDB connection error: ${err.message}`);
-    } else {
-      console.error('Unknown MongoDB connection error');
-    }
-    // Exit process with failure
+  const mongoURI = process.env.MONGODB_URI as string;
+  const maxRetries = parseInt(process.env.MONGODB_RETRY_COUNT || '5', 10);
+
+  if (!mongoURI) {
+    console.error('MongoDB URI is not defined in environment variables');
     process.exit(1);
   }
+
+  const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await mongoose.connect(mongoURI);
+      console.log('MongoDB Connected...');
+      return;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown MongoDB connection error';
+      console.error(`MongoDB connection attempt ${attempt} failed: ${msg}`);
+      if (attempt < maxRetries) {
+        console.log('Retrying connection...');
+        await delay(1000 * attempt);
+      }
+    }
+  }
+
+  console.error(`Unable to connect to MongoDB after ${maxRetries} attempts. Exiting.`);
+  process.exit(1);
 };
 
 export default connectDB;


### PR DESCRIPTION
## Summary
- enhance `start-dev.sh` with clearer logging about mongod startup
- detect port from `.env` when possible and show log path
- add simple retry loop in `connectDB`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' - offline)*
- `npm run build` *(fails: missing packages - offline)*

------
https://chatgpt.com/codex/tasks/task_e_6851ad118da0832ca98d01647ca25487