### PR TITLE
Add env example and ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/README.md
+++ b/README.md
@@ -52,3 +52,15 @@ export default tseslint.config({
   },
 })
 ```
+
+## Environment setup
+
+The backend relies on environment variables for database connection and token
+signing. Copy the example file and provide your own values:
+
+```bash
+cp server/.env.example server/.env
+```
+
+Open `server/.env` and replace the placeholders with your MongoDB URI and JWT
+secret.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration for the backend
+# Copy this file to `.env` and replace the placeholders with real values.
+MONGODB_URI=your_mongodb_uri_here
+JWT_SECRET=your_jwt_secret_here


### PR DESCRIPTION
## Summary
- ignore `.env` files in git
- add sample environment file for backend
- document how to set up the environment variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851ac18d6f0832cbc34ef7501bed981