### PR TITLE
Fix start script to use stored root directory

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+# Корневая директория проекта
+ROOT_DIR="$(pwd)"
+
 # Создаем директорию для данных MongoDB, если она не существует
-MONGODB_DATA_DIR="$(pwd)/data/db"
+MONGODB_DATA_DIR="$ROOT_DIR/data/db"
 mkdir -p "$MONGODB_DATA_DIR"
 
 # Лог-файл MongoDB
-MONGODB_LOG="$(pwd)/data/mongodb.log"
+MONGODB_LOG="$ROOT_DIR/data/mongodb.log"
 
 # Порт MongoDB по умолчанию
 MONGODB_PORT="27017"
@@ -56,12 +59,15 @@ fi
 
 # Запуск сервера в фоновом режиме
 echo "Запуск сервера..."
-cd "$(pwd)/server" && npm run dev &
+cd "$ROOT_DIR/server" && npm run dev &
 SERVER_PID=$!
+
+# Возвращаемся в корневую директорию
+cd "$ROOT_DIR"
 
 # Запуск клиента
 echo "Запуск клиента..."
-cd "$(pwd)" && npm run dev &
+npm run dev &
 CLIENT_PID=$!
 
 # Функция для корректного завершения процессов при выходе


### PR DESCRIPTION
## Summary
- store project root at the start of `start-dev.sh`
- start server via the stored root path and return to root to run client

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851b63e9800832c832a4e9d8c17d84f