### PR TITLE
Replace grep -oP with POSIX tools

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -12,7 +12,7 @@ MONGODB_PORT="27017"
 
 # Пытаемся получить порт из server/.env
 if [ -f "server/.env" ]; then
-    ENV_PORT=$(grep -oP '(?<=mongodb://[^:]+:)\d+' server/.env)
+    ENV_PORT=$(grep -Eo 'mongodb://[^:]+:[0-9]+' server/.env | sed 's|.*:||')
     if [ -n "$ENV_PORT" ]; then
         MONGODB_PORT="$ENV_PORT"
     fi


### PR DESCRIPTION
## Summary
- use `grep -E` and `sed` instead of `grep -oP` in `start-dev.sh`

## Testing
- `npm test` *(fails: Missing script)*
- `cd server && npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851b640051c832c8d7dda6b3843b567