### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ npm run dev
 The client will be available at `http://localhost:5173` and the API server at
 `http://localhost:5001` by default.
 
-=======
 ## Environment setup
 
 The backend relies on environment variables for database connection and token


### PR DESCRIPTION
## Summary
- remove extraneous `=======` line so the Environment setup header is adjacent to the preceding paragraph

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851b6411b40832caef2406f7a0f8fff