### PR TITLE
Fix .env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ npm run dev
 
 The client will be available at `http://localhost:5173` and the API server at
 `http://localhost:5001` by default.
-
-=======
 ## Environment setup
 
 The backend relies on environment variables for database connection and token

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,12 +1,5 @@
 PORT=5001
-# MongoDB connection string. Use a local instance or MongoDB Atlas
 MONGODB_URI=mongodb://localhost:27017/qazaqeduplus
-# Secret key for JWT tokens
 JWT_SECRET=your_jwt_secret_here
 NODE_ENV=development
-=======
-# Example environment configuration for the backend
-# Copy this file to `.env` and replace the placeholders with real values.
-MONGODB_URI=your_mongodb_uri_here
-JWT_SECRET=your_jwt_secret_here
 


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in README
- simplify server/.env.example to a single example

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851b642811c832c91681dbbd3827e85